### PR TITLE
fix(login): use icon for password visibility toggle

### DIFF
--- a/usecases/coding/login/index.html
+++ b/usecases/coding/login/index.html
@@ -47,27 +47,42 @@
                   class="password__icon password__icon--show"
                   id="togglePwdShowIcon"
                   viewBox="0 0 24 24"
-                  width="18"
-                  height="18"
+                  width="20"
+                  height="20"
                   aria-hidden="true"
+                  fill="none"
                 >
                   <path
-                    fill="currentColor"
-                    d="M12 5c5.6 0 9.8 4.6 11 6.1a1.4 1.4 0 0 1 0 1.8C21.8 14.4 17.6 19 12 19S2.2 14.4 1 12.9a1.4 1.4 0 0 1 0-1.8C2.2 9.6 6.4 5 12 5Zm0 2C7.7 7 4.2 10.5 3 12c1.2 1.5 4.7 5 9 5s7.8-3.5 9-5c-1.2-1.5-4.7-5-9-5Zm0 2.2a2.8 2.8 0 1 1 0 5.6 2.8 2.8 0 0 1 0-5.6Z"
+                    d="M2.5 12S6.5 5.5 12 5.5 21.5 12 21.5 12 17.5 18.5 12 18.5 2.5 12 2.5 12Z"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="3.2"
+                    stroke="currentColor"
+                    stroke-width="1.8"
                   />
                 </svg>
                 <svg
                   class="password__icon password__icon--hide"
                   id="togglePwdHideIcon"
                   viewBox="0 0 24 24"
-                  width="18"
-                  height="18"
+                  width="20"
+                  height="20"
                   aria-hidden="true"
                   hidden
+                  fill="none"
                 >
                   <path
-                    fill="currentColor"
-                    d="m3 4.2 1.4-1.4 16.8 16.8-1.4 1.4-3.2-3.2A11.3 11.3 0 0 1 12 19c-5.6 0-9.8-4.6-11-6.1a1.4 1.4 0 0 1 0-1.8A20 20 0 0 1 7 6.2L3 4.2Zm6.3 3.4A8.2 8.2 0 0 0 3 12c1.2 1.5 4.7 5 9 5 1.3 0 2.6-.3 3.8-.8l-1.7-1.7a2.8 2.8 0 0 1-3.8-3.8L9.3 7.6Zm11.7 4.5a20 20 0 0 1-3.4 3.8L16 14.3c2-1.2 3.5-2.8 4.5-4.3-1.2-1.5-4.7-5-9-5-.8 0-1.5.1-2.2.2L7.8 3.7C9 3.2 10.5 3 12 3c5.6 0 9.8 4.6 11 6.1.4.5.4 1.3 0 1.8Z"
+                    d="M10.6 6.1A8.9 8.9 0 0 1 12 5.5c5.5 0 9.5 6.5 9.5 6.5a17.4 17.4 0 0 1-2.6 3.2M14.7 14.9A3.2 3.2 0 0 1 9.1 9.3M6.2 8A17.4 17.4 0 0 0 2.5 12s4 6.5 9.5 6.5a8.9 8.9 0 0 0 4-.9M3.5 3.5l17 17"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
                   />
                 </svg>
                 <span class="sr-only" id="togglePwdText">显示密码</span>

--- a/usecases/coding/login/index.html
+++ b/usecases/coding/login/index.html
@@ -42,8 +42,35 @@
                 minlength="6"
                 required
               />
-              <button class="password__toggle" type="button" id="togglePwd" aria-label="显示密码">
-                显示
+              <button class="password__toggle" type="button" id="togglePwd" aria-label="显示密码" aria-pressed="false">
+                <svg
+                  class="password__icon password__icon--show"
+                  id="togglePwdShowIcon"
+                  viewBox="0 0 24 24"
+                  width="18"
+                  height="18"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill="currentColor"
+                    d="M12 5c5.6 0 9.8 4.6 11 6.1a1.4 1.4 0 0 1 0 1.8C21.8 14.4 17.6 19 12 19S2.2 14.4 1 12.9a1.4 1.4 0 0 1 0-1.8C2.2 9.6 6.4 5 12 5Zm0 2C7.7 7 4.2 10.5 3 12c1.2 1.5 4.7 5 9 5s7.8-3.5 9-5c-1.2-1.5-4.7-5-9-5Zm0 2.2a2.8 2.8 0 1 1 0 5.6 2.8 2.8 0 0 1 0-5.6Z"
+                  />
+                </svg>
+                <svg
+                  class="password__icon password__icon--hide"
+                  id="togglePwdHideIcon"
+                  viewBox="0 0 24 24"
+                  width="18"
+                  height="18"
+                  aria-hidden="true"
+                  hidden
+                >
+                  <path
+                    fill="currentColor"
+                    d="m3 4.2 1.4-1.4 16.8 16.8-1.4 1.4-3.2-3.2A11.3 11.3 0 0 1 12 19c-5.6 0-9.8-4.6-11-6.1a1.4 1.4 0 0 1 0-1.8A20 20 0 0 1 7 6.2L3 4.2Zm6.3 3.4A8.2 8.2 0 0 0 3 12c1.2 1.5 4.7 5 9 5 1.3 0 2.6-.3 3.8-.8l-1.7-1.7a2.8 2.8 0 0 1-3.8-3.8L9.3 7.6Zm11.7 4.5a20 20 0 0 1-3.4 3.8L16 14.3c2-1.2 3.5-2.8 4.5-4.3-1.2-1.5-4.7-5-9-5-.8 0-1.5.1-2.2.2L7.8 3.7C9 3.2 10.5 3 12 3c5.6 0 9.8 4.6 11 6.1.4.5.4 1.3 0 1.8Z"
+                  />
+                </svg>
+                <span class="sr-only" id="togglePwdText">显示密码</span>
               </button>
             </div>
             <p class="field__hint" id="passwordHint">密码至少 6 位</p>

--- a/usecases/coding/login/script.js
+++ b/usecases/coding/login/script.js
@@ -3,6 +3,9 @@
   const username = document.getElementById('username');
   const password = document.getElementById('password');
   const toggle = document.getElementById('togglePwd');
+  const toggleText = document.getElementById('togglePwdText');
+  const showIcon = document.getElementById('togglePwdShowIcon');
+  const hideIcon = document.getElementById('togglePwdHideIcon');
   const status = document.getElementById('status');
   const submitBtn = document.getElementById('submitBtn');
 
@@ -57,8 +60,11 @@
   toggle.addEventListener('click', () => {
     const isPwd = password.type === 'password';
     password.type = isPwd ? 'text' : 'password';
-    toggle.textContent = isPwd ? '隐藏' : '显示';
+    if (showIcon) showIcon.hidden = isPwd;
+    if (hideIcon) hideIcon.hidden = !isPwd;
+    if (toggleText) toggleText.textContent = isPwd ? '隐藏密码' : '显示密码';
     toggle.setAttribute('aria-label', isPwd ? '隐藏密码' : '显示密码');
+    toggle.setAttribute('aria-pressed', String(isPwd));
     password.focus();
   });
 

--- a/usecases/coding/login/styles.css
+++ b/usecases/coding/login/styles.css
@@ -119,11 +119,16 @@ body {
 }
 
 .password__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(0, 0, 0, 0.20);
   color: var(--muted);
   border-radius: 12px;
-  padding: 10px 12px;
+  padding: 0;
   cursor: pointer;
   transition: transform 80ms ease, border-color 120ms ease, color 120ms ease;
 }
@@ -135,6 +140,28 @@ body {
 
 .password__toggle:active {
   transform: translateY(1px);
+}
+
+.password__icon {
+  display: block;
+}
+
+.password__toggle:focus-visible {
+  border-color: rgba(96, 165, 250, 0.7);
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.18);
+  outline: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .row {

--- a/usecases/coding/login/styles.css
+++ b/usecases/coding/login/styles.css
@@ -146,6 +146,10 @@ body {
   display: block;
 }
 
+.password__icon[hidden] {
+  display: none;
+}
+
 .password__toggle:focus-visible {
   border-color: rgba(96, 165, 250, 0.7);
   box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.18);


### PR DESCRIPTION
## Summary
- replace text-based password visibility toggle with eye/eye-off icon button
- preserve accessibility by keeping screen-reader text and aria labels in sync
- add visual/focus styles for icon toggle button

## Testing
- manual check in browser: toggle switches password type and icon state correctly

Closes #6